### PR TITLE
Dev/categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@sanity/block-tools": "^0.139.6",
+    "@sanity/block-tools": "^1.149.0",
     "@sanity/client": "^0.139.0",
     "@sanity/import": "^0.139.1",
     "@sanity/schema": "^0.139.6",

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -39,9 +39,6 @@ async function buildJSONfromStream (stream) {
     })
 
     /**
-     * Get the categories
-     */
-    /**
      * Collate unique categories and tags
      */
     const categories = [];


### PR DESCRIPTION
- Update `block-tools` to latest version
- Collects unique categories and tags instead of adding a new line every time one is found in the XML
- Separates Categories and Tags as different entities, and builds them as an array of references